### PR TITLE
Add stable-20210108 tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 env:
   global:
     - STABLE_P4C_COMMIT: e2934ab
+    - STABLE_20210108_P4C_COMMIT: 41b6968
     - LATEST_P4C_COMMIT: "`wget -qO- http://api.github.com/repos/p4lang/p4c/commits/master | grep -m1 '\"sha\"' | cut -d '\"' -f4 | cut -c1-7`"
     - MAKEFLAGS: "'-j2'"
   matrix:
@@ -15,6 +16,9 @@ env:
     - TAGNAME: stable
       P4C_COMMIT: $STABLE_P4C_COMMIT
       PROTOBUF_VERSION: 3.2.0
+    - TAGNAME: stable-20210108
+      P4C_COMMIT: $STABLE_20210108_P4C_COMMIT
+      PROTOBUF_VERSION: 3.6.1
 
 before_install:
   - export LOCAL_RUNTIME_IMAGE=p4c-$TAGNAME

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The image comes in two tags:
 * `opennetworking/p4c:stable` Built using an arbitrarily selected p4c commit that
   produces outputs known to work well with the ONOS development and testing
   environment.
+* `opennetworking/p4c:stable-20210108` Built using a p4c commit from 2021-01-08 that
+  supports `@p4runtime_translation` annotations.
 
 ## Status [![Build Status](https://travis-ci.org/opennetworkinglab/p4c-docker.svg?branch=master)][Travis]
 
@@ -33,6 +35,9 @@ Images are built daily using [Travis CI][Travis] and pushed to
 
 [![](https://images.microbadger.com/badges/version/opennetworking/p4c:stable.svg)](https://microbadger.com/images/opennetworking/p4c:stable)
 [![](https://images.microbadger.com/badges/image/opennetworking/p4c:stable.svg)](https://microbadger.com/images/opennetworking/p4c:stable)
+
+[![](https://images.microbadger.com/badges/version/opennetworking/p4c:stable-20210108.svg)](https://microbadger.com/images/opennetworking/p4c:stable-20210108)
+[![](https://images.microbadger.com/badges/image/opennetworking/p4c:stable-20210108.svg)](https://microbadger.com/images/opennetworking/p4c:stable-20210108)
 
 [Travis]: https://travis-ci.org/opennetworkinglab/p4c-docker
 [Docker Hub]: https://hub.docker.com/r/opennetworking/p4c


### PR DESCRIPTION
Adding a `stable-20210108` tag. This tag is needed because `stable` doesn't support `@p4runtime_translation` annotations needed for [https://gerrit.onosproject.org/c/onos/+/24215](https://gerrit.onosproject.org/c/onos/+/24215).